### PR TITLE
Removing Secret Key plain text

### DIFF
--- a/README.md
+++ b/README.md
@@ -43,7 +43,7 @@ Run the following code in Powershell if using windows or the terminal using Linu
   MAC:
   `docker run --rm -it --volume "$(pwd):/rails_app" -e DATABASE_USER=test_app -e DATABASE_PASSWORD=test_password -p 3000:3000 dmartinez05/ruby_rails_postgresql:latest`
 
-  Windows:
+  Windows Locally:
   `docker run --rm -it --volume "${PWD}:/rails_app" -e DATABASE_USER=test_app -e DATABASE_PASSWORD=test_password -p 3000:3000 dmartinez05/ruby_rails_postgresql:latest`
   
   `cd rails_app`
@@ -57,9 +57,22 @@ Run the app
 
 The application can be seen using a browser and navigating to http://localhost:3000/
 
+
 ## Environmental Variables/Files ##
 
-N/A
+GOOGLE_OAUTH_CLIENT_ID = The client ID for the google project used for authentication
+
+GOOGLE_OAUTH_CLIENT_SECRET = The secret key for the google project used for authentication
+
+## Google Oauth ##
+
+By default the code runs locally without accessing live server for google authentication. 
+The mock account used to simulate logging in can be found in: 
+[config/environments/development.rb](config/environments/development.rb).
+This mocks the act of signing in with the email listed. 
+
+To link a google project add the corresponding environments variables to the docker run command:\
+  `-e GOOGLE_OAUTH_CLIENT_ID=<Client-ID> -e GOOGLE_OAUTH_CLIENT_SECRET=<Client Secret>`
 
 ## Deployment ##
 

--- a/app/views/admins/index.html.erb
+++ b/app/views/admins/index.html.erb
@@ -1,6 +1,83 @@
 
+<div class="container">
+  <h1 style ="text-align: center;">Welcome to the Admins Page!</h1>
 
-<h1 style ="text-align: center;">Welcome to the Admins Page!</h1>
+
+  <h4>General Guidelines</h4>
+  <ul>
+    <li>Navigate to the desired area using the Admin Menu.</li>
+    <li>The initial page will show the list of items for the selected area along with some options.</li>
+  </ul>
+    <h5>Options</h5>
+  <ul>
+    <li>New items can be via <div class="submit-button"><div class="btn btn-success"> New ITEM </div></div></li>
+    <li>Item information is displayed using <div class="submit-button"><div class="btn btn-outline-info"> Show </div></div></li>
+    <li>Items can be edited using <div class="submit-button"><div class="btn btn-outline-info"> Edit </div></div> </li>
+    <li>Items can be deleted using <div class="submit-button"><div class="btn btn-outline-danger">Destroy</div></div></li>
+  </ul>
+  <br>
+  <h4>Specifics On Areas</h4>
+  <h5>People/Members</h5>
+  <p>
+    The people/member table is the basis for certain other tables. It is required for a person
+    to exist before adding an <strong>Officer</strong> or an <strong>Alumni</strong>
+  </p>
+  <p>
+    Deleting a person will delete the following items associated with that person:
+  </p>
+  <ul>
+    <li>Officer</li>
+    <li>Alumni</li>
+    <li>Position</li>
+  </ul>
 
 
-<p>This is where a basic wiki of how to use this site will be placed</p>
+  <h5>Admins</h5>
+  <p>
+    Admins are added and removed via editing items in the people section. An existing admin can update a person to be
+    an admin by editing a person item, checking the 'is_admin' box.
+    Similar, an admin can be removed by unchecking this box.
+  </p>
+  <p>The email associated with the person is what needs to be used when logging in.</p>
+
+
+  <h5>Officers</h5>
+  <p><strong>
+    An officer can only be made after creating a person with the base information.
+  </strong></p>
+  <p>
+    Officers may have a photo that can be uploaded when creating or editing an officer.
+    No photo being uploaded will result in a default silhouette image being used.
+  </p>
+  <p>
+    The officers listed in the Officer table are displayed in the public officer page.
+  </p>
+
+  <h5>Alumni</h5>
+  <p><strong>
+    An Alumni can only be made after creating a person with the base information.
+  </strong></p>
+  <p>
+    The alumni page is used to populated the list of alumni display on the main page.
+  </p>
+
+
+  <h5>Company</h5>
+  <p>
+    The company area is used to populated the list of companies displayed on the main page.
+    It allows create and updating a list of companies with their logo, name, and website.
+  </p>
+
+  <h5>Position</h5>
+  <p>
+    This area is for linking a person to a company.
+    With this an admin can list who worked at what company at what position in said company.
+  </p>
+
+  <h5>Contact Form</h5>
+  <p>
+    This area allows for viewing the list of messages submit via the public contact form.
+    It displays the intended officer, the email of the user, the name of user, and their message.
+  </p>
+</div>
+

--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -7,7 +7,7 @@
     <script src="https://code.jquery.com/jquery-3.2.1.slim.min.js" integrity="sha384-KJ3o2DKtIkvYIK3UENzmM7KCkRr/rE9/Qpg6aAZGJwFDMVNA/GpGFF93hXpG5KkN" crossorigin="anonymous"></script>
     <script src="https://cdn.jsdelivr.net/npm/popper.js@1.12.9/dist/umd/popper.min.js" integrity="sha384-ApNbgh9B+Y1QKtv3Rn7W3mgPxhU9K/ScQsAP7hUibX39j7fakFPskvXusvfa0b4Q" crossorigin="anonymous"></script>
     <script src="https://cdn.jsdelivr.net/npm/bootstrap@4.0.0/dist/js/bootstrap.min.js" integrity="sha384-JZR6Spejh4U02d8jOt6vLEHfe/JQGiRRSQQxSfFWpi1MquVdAyjUar5+76PVCmYl" crossorigin="anonymous"></script>
-    <title>TestApp</title>
+    <title>AADE</title>
     <meta name="viewport" content="width=device-width,initial-scale=1">
     <%= csrf_meta_tags %>
     <%= csp_meta_tag %>

--- a/config/environments/development.rb
+++ b/config/environments/development.rb
@@ -73,6 +73,24 @@ Rails.application.configure do
 
   # Uncomment if you wish to allow Action Cable access from any origin.
   # config.action_cable.disable_request_forgery_protection = true
-  ENV['GOOGLE_OAUTH_CLIENT_ID'] = '284431453271-b7fh18v4g6e9js490qanodlndsh73356.apps.googleusercontent.com'
-  ENV['GOOGLE_OAUTH_CLIENT_SECRET'] = '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'
+  #ENV['GOOGLE_OAUTH_CLIENT_ID'] = '284431453271-b7fh18v4g6e9js490qanodlndsh73356.apps.googleusercontent.com'
+  #ENV['GOOGLE_OAUTH_CLIENT_SECRET'] = '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'
 end
+
+# This setups Oauth to NOT use the live google server if selected
+# IF not set a user will need to specify a GOOGLE_OAUTH_CLIENT_ID and GOOGLE_OAUTH_CLIENT_SECRET they wish to route to
+if ENV['GOOGLE_OAUTH_LOCAL'] == "1"
+  #This enables test mode which auto redirect to the auth/google/callback. Meaning, no call is made to actual google authentication server
+  OmniAuth.config.test_mode = true
+
+  # This specifies the mock account that will be logging in. Change email to change which account is logging in when clicking 'Sign In'
+  OmniAuth.config.add_mock(:google_oauth2, { info: { email: 'davidking@tamu.edu'} })
+
+  #This configures auth and devise to work together
+  Rails.application.env_config['devise.mapping'] = Devise.mappings[:person] # If using Devise
+  Rails.application.env_config['omniauth.auth'] = OmniAuth.config.mock_auth[:google_oauth2]
+else
+  Rails.application.env_config['GOOGLE_OAUTH_CLIENT_ID'] = ENV['GOOGLE_OAUTH_CLIENT_ID']
+  Rails.application.env_config['GOOGLE_OAUTH_CLIENT_SECRET'] = ENV['GOOGLE_OAUTH_CLIENT_SECRET']
+end
+

--- a/config/environments/development.rb
+++ b/config/environments/development.rb
@@ -73,13 +73,11 @@ Rails.application.configure do
 
   # Uncomment if you wish to allow Action Cable access from any origin.
   # config.action_cable.disable_request_forgery_protection = true
-  #ENV['GOOGLE_OAUTH_CLIENT_ID'] = '284431453271-b7fh18v4g6e9js490qanodlndsh73356.apps.googleusercontent.com'
-  #ENV['GOOGLE_OAUTH_CLIENT_SECRET'] = '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'
 end
 
 # This setups Oauth to NOT use the live google server if selected
 # IF not set a user will need to specify a GOOGLE_OAUTH_CLIENT_ID and GOOGLE_OAUTH_CLIENT_SECRET they wish to route to
-if ENV['GOOGLE_OAUTH_LOCAL'] == "1"
+if !(ENV.has_key?("GOOGLE_OAUTH_CLIENT_ID") || ENV.has_key?("GOOGLE_OAUTH_CLIENT_SECRET"))
   #This enables test mode which auto redirect to the auth/google/callback. Meaning, no call is made to actual google authentication server
   OmniAuth.config.test_mode = true
 
@@ -89,7 +87,7 @@ if ENV['GOOGLE_OAUTH_LOCAL'] == "1"
   #This configures auth and devise to work together
   Rails.application.env_config['devise.mapping'] = Devise.mappings[:person] # If using Devise
   Rails.application.env_config['omniauth.auth'] = OmniAuth.config.mock_auth[:google_oauth2]
-else
+elsif
   Rails.application.env_config['GOOGLE_OAUTH_CLIENT_ID'] = ENV['GOOGLE_OAUTH_CLIENT_ID']
   Rails.application.env_config['GOOGLE_OAUTH_CLIENT_SECRET'] = ENV['GOOGLE_OAUTH_CLIENT_SECRET']
 end

--- a/config/environments/production.rb
+++ b/config/environments/production.rb
@@ -117,6 +117,4 @@ Rails.application.configure do
   # config.active_record.database_selector = { delay: 2.seconds }
   # config.active_record.database_resolver = ActiveRecord::Middleware::DatabaseSelector::Resolver
   # config.active_record.database_resolver_context = ActiveRecord::Middleware::DatabaseSelector::Resolver::Session
-  ENV['GOOGLE_OAUTH_CLIENT_ID'] = '284431453271-b7fh18v4g6e9js490qanodlndsh73356.apps.googleusercontent.com'
-  ENV['GOOGLE_OAUTH_CLIENT_SECRET'] = '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'
 end


### PR DESCRIPTION
IMPORTANT NOTE:
To run through the ACUATAL Oauth:
docker run --rm -it --volume "${PWD}:/csce431" -e DATABASE_USER=test_app -e DATABASE_PASSWORD=test_password -e GOOGLE_OAUTH_CLIENT_ID='284431453271-b7fh18v4g6e9js490qanodlndsh73356.apps.googleusercontent.com' -e GOOGLE_OAUTH_CLIENT_SECRET='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' -p 3000:
3000 dmartinez05/ruby_rails_postgresql:latest
Otherwise, it'll use the mock account listed at the bottom of config/environments/development.rb

Also need to add ENV to heroku